### PR TITLE
Updated Footer to add Github to icons

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,8 +4,9 @@
             <div class="col-lg-12" style="text-align:center">
                 <p>
                     {% for network in site.social %}
-                        <a href="{{ network.url }}" class="btn-social btn-outline"><i class="fa fa-{{ network.title }}"></i></a>
+                        <a href="{{ network.url }}" class="btn-social btn-outline" target="_blank"><i class="fa fa-{{ network.title }}"></i></a>
                     {% endfor %}
+                    <a href="https://github.com/scorelab" class="btn-social btn-outline" target="_blank"><i class="fa fa-github"></i></a>
                 </p>
             </div>
         </div><!--/row -->


### PR DESCRIPTION
Added fontawesome Github icon directly to the footer.html file within the includes folder.
Added link to Github icon for SCoRe Labs Github repos.
Added Target blank to stop visitors from leaving the website when a link is clicked.